### PR TITLE
Implement Rail Fence Cipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ o
 - [X] `atbash`: aka Atbash Cipher
 - [X] `bacon`: aka Baconian Cipher
 - [X] `barbie-N`: aka Barbie Typewriter (*N* belongs to [1, 4])
-- [X] `citrix`: aka Citrix CTX1 passord encoding
+- [X] `citrix`: aka Citrix CTX1 password encoding
+- [X] `rail`: aka Rail Fence Cipher 
 - [X] `rotN`: aka Caesar cipher (*N* belongs to [1,25])
 - [X] `scytaleN`: encrypts using the number of letters on the rod (*N* belongs to [1,[)
 - [X] `shiftN`: shift ordinals (*N* belongs to [1,255])

--- a/codext/crypto/__init__.py
+++ b/codext/crypto/__init__.py
@@ -4,6 +4,7 @@ from .atbash import *
 from .bacon import *
 from .barbie import *
 from .citrix import *
+from .railfence import *
 from .rot import *
 from .scytale import *
 from .shift import *

--- a/codext/crypto/railfence.py
+++ b/codext/crypto/railfence.py
@@ -14,14 +14,20 @@ from ..__common__ import *
 
 
 __examples__ = {
-    'enc(rail-5-3)': {'this is a test' : 'it sss etiath '},
-    'dec(rail-7-4)': {'a  stiet shsti': 'this is a test'}
+    'enc(rail-5-3|rail_5_3)': {'this is a test' : 'it sss etiath '},
+    'enc(railup-5-3|railup_5_3)' :{'this is a test': 'h tiats e ssit'},
+    'dec(rail-7-4|rail_7_4)': {'a  stiet shsti': 'this is a test'}
 }
 
 
 
-def __buildf(text, rails, offset = 0) : 
-    l, rail, dr = len(text), offset, 1
+def __buildf(text, rails, offset = 0, up = 0) : 
+    l, rail = len(text), offset
+    if up != '' :
+        dr = -1
+        rail = rails - offset - 1
+    else : 
+        dr = 1
     f = [["#"] * l for i in range(rails)]
     for x in range(l) : 
         f[rail][x] = text[x]
@@ -30,16 +36,12 @@ def __buildf(text, rails, offset = 0) :
         elif rail <= 0:
             dr = 1
         rail += dr
-    for elem in f : 
-        print(elem)
     return f
 
-def railfence_encode(rails, offset = 0) :  
+def railfence_encode(up = 0, rails = 3, offset = 0) :  
     def encode(text, errors="strict") : 
-        print(len(text))
-
         c,l = '', len(text)
-        f = __buildf(text,rails,offset)
+        f = __buildf(text,rails,offset, up)
         for r in range(rails) : 
             for x in range(l) :
                 if f[r][x] != '#' : 
@@ -47,9 +49,9 @@ def railfence_encode(rails, offset = 0) :
         return c, l
     return encode
 
-def railfence_decode(rails, offset = 0) : 
+def railfence_decode(up = 0,rails = 3, offset = 0) : 
     def decode(text, errors = 'strict') : 
-        f = __buildf("x" * len(text), rails, offset)
+        f = __buildf("x" * len(text), rails, offset, up)
         plain, i = '', 0
         ra, l = range(rails), range(len(text))
 
@@ -69,7 +71,4 @@ def railfence_decode(rails, offset = 0) :
 
     return decode
 
-add("rail", railfence_encode, railfence_decode, r"rail-(\d+)\-(\d+)$")
-
-#rail-(\d+)\-(\d+)
-#rail-(\d+)(\-*(\d+))
+add("rail", railfence_encode, railfence_decode, r"rail(up)?[-_](\d+)[-_](\d+)$")

--- a/codext/crypto/railfence.py
+++ b/codext/crypto/railfence.py
@@ -28,7 +28,9 @@ def __buildf(text, rails, offset = 0, up = 0) :
         rail = rails - offset - 1
     else : 
         dr = 1
+
     f = [["#"] * l for i in range(rails)]
+
     for x in range(l) : 
         f[rail][x] = text[x]
         if rail >= rails - 1:
@@ -41,7 +43,7 @@ def __buildf(text, rails, offset = 0, up = 0) :
 def railfence_encode(rails = 3, offset = 0, up = 0) :  
     def encode(text, errors="strict") : 
         c,l = '', len(text)
-        f = __buildf(text,rails,offset, up)
+        f = __buildf(text, rails, offset, up)
         for r in range(rails) : 
             for x in range(l) :
                 if f[r][x] != '#' : 

--- a/codext/crypto/railfence.py
+++ b/codext/crypto/railfence.py
@@ -14,7 +14,8 @@ from ..__common__ import *
 
 
 __examples__ = {
-    'enc(rail-5-3)': "it sss etiath "
+    'enc(rail-5-3)': {'this is a test' : 'it sss etiath '},
+    'dec(rail-7-4)': {'a  stiet shsti': 'this is a test'}
 }
 
 

--- a/codext/crypto/railfence.py
+++ b/codext/crypto/railfence.py
@@ -15,7 +15,7 @@ from ..__common__ import *
 
 __examples__ = {
     'enc(rail-5-3|rail_5_3)': {'this is a test' : 'it sss etiath '},
-    'enc(railup-5-3|railup_5_3)' :{'this is a test': 'h tiats e ssit'},
+    'enc(rail-5-3-up|rail_5_3-up)' :{'this is a test': 'h tiats e ssit'},
     'dec(rail-7-4|rail_7_4)': {'a  stiet shsti': 'this is a test'}
 }
 
@@ -38,7 +38,7 @@ def __buildf(text, rails, offset = 0, up = 0) :
         rail += dr
     return f
 
-def railfence_encode(up = 0, rails = 3, offset = 0) :  
+def railfence_encode(rails = 3, offset = 0, up = 0) :  
     def encode(text, errors="strict") : 
         c,l = '', len(text)
         f = __buildf(text,rails,offset, up)
@@ -49,7 +49,7 @@ def railfence_encode(up = 0, rails = 3, offset = 0) :
         return c, l
     return encode
 
-def railfence_decode(up = 0,rails = 3, offset = 0) : 
+def railfence_decode(rails = 3, offset = 0, up = 0) : 
     def decode(text, errors = 'strict') : 
         f = __buildf("x" * len(text), rails, offset, up)
         plain, i = '', 0
@@ -71,4 +71,4 @@ def railfence_decode(up = 0,rails = 3, offset = 0) :
 
     return decode
 
-add("rail", railfence_encode, railfence_decode, r"rail(up)?[-_](\d+)[-_](\d+)$")
+add("rail", railfence_encode, railfence_decode, r"rail[-_](\d+)[-_](\d+)[-_]?(up)?$")

--- a/codext/crypto/railfence.py
+++ b/codext/crypto/railfence.py
@@ -1,0 +1,74 @@
+# -*- coding: UTF-8 -*-
+"""Rail Fence Cipher Codec - rail fence encoding.
+
+This codec:
+- en/decodes strings from str to str
+- en/decodes strings from bytes to bytes
+- decodes file content to str (read)
+- encodes file content from str to bytes (write)
+"""
+
+
+
+from ..__common__ import *
+
+
+__examples__ = {
+    'enc(rail-5-3)': "it sss etiath "
+}
+
+
+
+def __buildf(text, rails, offset = 0) : 
+    l, rail, dr = len(text), offset, 1
+    f = [["#"] * l for i in range(rails)]
+    for x in range(l) : 
+        f[rail][x] = text[x]
+        if rail >= rails - 1:
+            dr = -1
+        elif rail <= 0:
+            dr = 1
+        rail += dr
+    for elem in f : 
+        print(elem)
+    return f
+
+def railfence_encode(rails, offset = 0) :  
+    def encode(text, errors="strict") : 
+        print(len(text))
+
+        c,l = '', len(text)
+        f = __buildf(text,rails,offset)
+        for r in range(rails) : 
+            for x in range(l) :
+                if f[r][x] != '#' : 
+                    c += f[r][x]
+        return c, l
+    return encode
+
+def railfence_decode(rails, offset = 0) : 
+    def decode(text, errors = 'strict') : 
+        f = __buildf("x" * len(text), rails, offset)
+        plain, i = '', 0
+        ra, l = range(rails), range(len(text))
+
+        #Put the characters in the right place
+        for r in ra:
+            for x in l :            
+                if f[r][x] == "x" : 
+                    f[r][x] = text[i]
+                    i += 1
+        #Read the characters in the right order
+        for x in l : 
+            for r in ra:
+                if f[r][x] != '#' : 
+                    plain += f[r][x]
+
+        return plain, len(plain)
+
+    return decode
+
+add("rail", railfence_encode, railfence_decode, r"rail-(\d+)\-(\d+)$")
+
+#rail-(\d+)\-(\d+)
+#rail-(\d+)(\-*(\d+))

--- a/docs/enc/crypto.md
+++ b/docs/enc/crypto.md
@@ -134,9 +134,7 @@ This implements the Rail Fence encoding algorithm.
 
 **Codec** | **Conversions** | **Aliases** | **Comment**
 :---: | :---: | --- | ---
-`rail` | text <-> rail fence ciphertext, X rails and Y offset | `rail-X-Y`, `rail_X_Y`| The encoding fence is built from the top. Careful to trailing whitespaces. 
-`railup` | text <-> rail fence ciphertext, X rails and Y offset  | `railup-X-Y`, `railup_X_Y`| The encoding fence is built from the bottom. Inverted compaired to the `rail` codec.
-
+`rail` | text <-> rail fence ciphertext, X rails and Y offset | `rail-X-Y`, `rail_X_Y`, `rail-X-Y-up`| The encoding fence is built from the top. Careful to trailing whitespaces. The `up` flag is used to build the fence from the bottom to the top.
 ```python
 >>> codext.encode("this is a test", "rail-5-3")
 'it sss etiath '

--- a/docs/enc/crypto.md
+++ b/docs/enc/crypto.md
@@ -128,6 +128,23 @@ This implements the Citrix CTX1 password encoding algorithm.
 
 -----
 
+### Rail Fence Cipher
+
+This implements the Rail Fence encoding algorithm.
+
+**Codec** | **Conversions** | **Aliases** | **Comment**
+:---: | :---: | --- | ---
+`rail` | text <-> rail fence ciphertext, X rails and Y offset | `rail-X-Y`, `rail_X_Y`| The encoding fence is built from the top. Careful to trailing whitespaces. 
+`railup` | text <-> rail fence ciphertext, X rails and Y offset  | `railup-X-Y`, `railup_X_Y`| The encoding fence is built from the bottom. Inverted compaired to the `rail` codec.
+
+```python
+>>> codext.encode("this is a test", "rail-5-3")
+'it sss etiath '
+>>> codext.decode("it sss etiath ", "rail-5-3")
+'this is a test'
+```
+
+-----
 ### ROT N
 
 This is a dynamic encoding, that is, it can be called with an integer to define the ROT offset. Encoding will apply a positive offset, decoding will apply a negative one.


### PR DESCRIPTION
Tests pass. 

RegEx might need a fix : `rail-5-3-` is recognized as a valid codec (ending dash is too much). Only `rail-5-3` or `rail-5-3-up` should be recognized. Couldn't manage to get that right.

When encoding, there might be trailing whitespaces (which is normal), but users might forget one when copy/pasting. I left them invisible to ease the integration with other tools. 