### PR TITLE
Fix Base45 dropping trailing bytes on non-ASCII input

### DIFF
--- a/src/codext/base/base45.py
+++ b/src/codext/base/base45.py
@@ -34,7 +34,10 @@ def base45_encode(mode):
     b45 = _get_charset(B45, mode)
     def encode(text, errors="strict"):
         t, s = b(text), ""
-        for i in range(0, len(text), 2):
+        # iterate over the byte sequence (t), not len(text): when the input
+        # holds non-ASCII characters, b(text) is longer than text and using
+        # len(text) silently drops the trailing bytes
+        for i in range(0, len(t), 2):
             n = 256 * __ord(t[i])
             try:
                 n += __ord(t[i+1])
@@ -54,7 +57,7 @@ def base45_decode(mode):
     def decode(text, errors="strict"):
         t, s = b(text), ""
         ehandler = handle_error("base45", errors, decode=True)
-        for i in range(0, len(text), 3):
+        for i in range(0, len(t), 3):
             try:
                 n = b45[__chr(t[i])]
             except KeyError:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -211,6 +211,19 @@ class TestCodecsBase(TestCase):
         self.assertRaises(ValueError, codecs.decode, b(B100)[1:], "base100")
         self.assertIsNotNone(codecs.decode(b(B100) + b"\n", "base100", "ignore"))
     
+    def test_codec_base45(self):
+        # RFC 9285 test vectors
+        for s, b45 in [("AB", "BB8"), ("Hello!!", "%69 VD92EX0"), ("base-45", "UJCLQE7W581")]:
+            self.assertEqual(codecs.encode(s, "base45"), b45)
+            self.assertEqual(codecs.encode(b(s), "base45"), b(b45))
+            self.assertEqual(codecs.decode(b45, "base45"), s)
+            self.assertEqual(codecs.decode(b(b45), "base45"), b(s))
+        # a trailing non-ASCII byte must not be dropped (byte length, not str length, drives encoding)
+        self.assertEqual(codecs.encode(b"\xcf\xb1\x1b", "base45"), b"OBQR0")
+        self.assertEqual(codecs.decode(b"OBQR0", "base45"), b"\xcf\xb1\x1b")
+        for data in [b"\xff\xfe", b"hello", b"\x00", b"\x80\x81\x82\x83\x84"]:
+            self.assertEqual(codecs.decode(codecs.encode(data, "base45"), "base45"), data)
+
     def test_codec_base_generic(self):
         for n in range(2, 255):
             bn = "base{}_generic".format(n)


### PR DESCRIPTION
## Problem

The Base45 codec silently drops trailing bytes when the input contains non-ASCII content, producing output that is too short and no longer round-trips.

```python
>>> import codext
>>> codext.encode(b'\xcf\xb1\x1b', 'base45')
b'OBQ'          # should be b'OBQR0'
>>> codext.decode(codext.encode(b'\xcf\xb1\x1b', 'base45'), 'base45')
b'\xcf\xb1'      # the trailing 0x1b byte is lost
```

## Cause

`base45_encode`/`base45_decode` iterate with `range(0, len(text), step)` but index into `t = b(text)`. Because the codec layer converts a bytes input to `str` (UTF-8) before the codec runs, `b(text)` is longer than `text` whenever the content is non-ASCII, so `len(text)` ends the loop early and the final group is never emitted. For `b'\xcf\xb1\x1b'` (`\xcf\xb1` decodes to the single character U+03F1), `text` has length 2 while the byte sequence has length 3, dropping the third byte.

## Fix

Iterate over `len(t)` (the actual byte sequence) in both functions. Encoded output now matches RFC 9285 and the reference `base45` implementation, and encoding round-trips for arbitrary byte input.

## Tests

Added `test_codec_base45` covering the RFC 9285 vectors (`AB`, `Hello!!`, `base-45`), the exact regression value (`b'\xcf\xb1\x1b'` -> `b'OBQR0'`), and round-trips for binary inputs. The full test suite passes.

I worked on this with AI assistance under my direction and reviewed the change myself.