### PR TITLE
Fixed KeyError on bare crc16 and crc codecs

### DIFF
--- a/src/codext/checksums/crc.py
+++ b/src/codext/checksums/crc.py
@@ -13,6 +13,7 @@ from ..__common__ import add
 
 CRC = {
     '': {
+        '':              (0x1021, 0xc6c6, True, True, 0, 0xbf05),
         'a':             (0x1021, 0xc6c6, True, True, 0, 0xbf05),
     },
     8: {
@@ -78,6 +79,7 @@ CRC = {
         'mpt1327':       (0x6815, 0, False, False, 1, 0x2566),
     },
     16: {
+        '':              (0x8005, 0, True, True, 0, 0xbb3d),
         'acorn':         (0x1021, 0, False, False, 0, 0x31c3),
         'arc':           (0x8005, 0, True, True, 0, 0xbb3d),
         'atom':          (0x002d, 0, True, True, 0, 0x4287),

--- a/tests/test_manual.py
+++ b/tests/test_manual.py
@@ -106,6 +106,25 @@ class ManualTestCase(TestCase):
         for s, r in [("", ""), ("0", "0"), ("1", "8"), ("7992739871", "3")]:
             self.assertEqual(codecs.encode(s, "luhn"), r)
         self.assertEqual(codecs.encode("-", "luhn", errors="ignore"), "")
+
+    def test_codec_crc_bare_defaults(self):
+        # a crc<width> used without a variant suffix must resolve to that family's default ;
+        # width 16 and the crc-a family had no default and crashed with KeyError instead
+        from codext.checksums.crc import CRC
+        for n in CRC.keys():
+            name = "crc%d" % n if isinstance(n, int) else "crc"
+            expected = "%0{}x".format(round((n or 16)/4+.5)) % CRC[n][""][5]
+            self.assertEqual(codecs.encode("123456789", name), expected)
+            self.assertEqual(codecs.encode(b"123456789", name), b(expected))
+        # bare crc-16 is CRC-16/ARC (poly 0x8005), the same as its arc/ibm/lha aliases
+        for name in ["crc16", "crc-16", "crc_16", "crc16-arc", "crc16-ibm", "crc16-lha"]:
+            self.assertEqual(codecs.encode("123456789", name), "bb3d")
+        # bare crc is CRC-A, the same as the crca alias
+        self.assertEqual(codecs.encode("123456789", "crc"), "bf05")
+        self.assertEqual(codecs.encode("123456789", "crca"), "bf05")
+        # adding a default must not make an unknown variant resolve
+        self.assertRaises(LookupError, codecs.encode, "123456789", "crc16-bad")
+        self.assertRaises(LookupError, codecs.encode, "123456789", "crc-bad")
     
     def test_codec_dummy_str_manips(self):
         STR = "this is a test"


### PR DESCRIPTION
`codext.encode(data, "crc16")` — the most common CRC width — raises `KeyError: ''`, and so does a bare `crc`, while every other width resolves fine with a bare name:

```
>>> codext.encode(b"123456789", "crc16")
KeyError: ''
>>> codext.encode(b"123456789", "crc8")
b'f4'
```

Root cause: in `checksums/crc.py` a bare `crcN` resolves to the `''` key of that width's variant table. Every width defines that `''` default except width 16, and the top-level crc-a table only has `'a'` — so those two are the only bare names that crash.

I checked the rest of the table is sound: `crc("123456789", …)` matches the stored `check` value for all 162 registered variants (0 mismatches), so the only defect is the two missing defaults. This adds them:

- `crc16` → CRC-16/ARC (poly `0x8005`) = reveng's canonical "CRC-16", identical to the existing `arc`/`ibm`/`lha` entries → `bb3d`
- `crc` → CRC-A, identical to `crca` → `bf05`

The test extends the existing checksum test with an invariant that every registered `crc<width>` (and bare `crc`) resolves without a variant suffix and equals its default `check`, so a future width added without a `''` default would be caught.

If you'd rather keep bare `crc16` explicit, the alternative is to raise a clear `ValueError` ("ambiguous, specify a variant") instead of `KeyError` — I defaulted it to stay consistent with the other 16 widths.
